### PR TITLE
chore: fix typos

### DIFF
--- a/.changeset/ripe-suns-smash.md
+++ b/.changeset/ripe-suns-smash.md
@@ -1,0 +1,5 @@
+---
+"haywire": patch
+---
+
+Fixed typos in README and docstrings

--- a/tools/haywire/src/lib/binding.ts
+++ b/tools/haywire/src/lib/binding.ts
@@ -89,7 +89,7 @@ export class Binding<
     public readonly scope: Scopes = transientScope;
 
     /**
-     * @param outputId - identifer of type returned by provider
+     * @param outputId - identifier of type returned by provider
      * @param depIds - list of dependency types, in order that will be passed to provider
      * @param isAsync - flag to indicate provider returns a promise of the output id
      * @param provider - method to calculate output id based on dependencies. If `isAsync=true`, can return a promise
@@ -329,7 +329,7 @@ export class DepsBindingBuilder<
     readonly #outputId: OutputId;
     readonly #depIds: DependencyIds;
     /**
-     * @param outputId - output identifer
+     * @param outputId - output identifier
      * @param depIds - dependency ids, in order that will be passed to provider
      */
     public constructor(outputId: OutputId, depIds: DependencyIds) {

--- a/tools/haywire/src/lib/container.ts
+++ b/tools/haywire/src/lib/container.ts
@@ -1327,7 +1327,7 @@ export class AsyncContainer<Outputs extends [Extendable]> {
      * This resolutin will kick off its own recursive requests to `#getMaybeSync`, and while the base case is not explicitly
      * stated, this is safe because of prior checks ensure the container has a healthy setup.
      *
-     * @param binding - binding of identifer being requested
+     * @param binding - binding of identifier being requested
      * @param requestCache - current request cache, shared across entire request
      * @param supplierCache - current scope cache, potentially same as requestCache,
      * which can be used to determine if request singletons need to be instantiated first

--- a/tools/haywire/src/lib/identifier.ts
+++ b/tools/haywire/src/lib/identifier.ts
@@ -197,7 +197,7 @@ export class HaywireId<
      * Any annotations like `nullable` or `supplier` are removed.
      *
      * @example
-     * const id = identifer();
+     * const id = identifier();
      * id.nullable().lateBinding().baseId() === id; // true
      *
      * @returns generic form of identifier


### PR DESCRIPTION
👋 Hey I was reading the documentation for haywire and noticed a few typos. Not sure if this is something that requires a changeset but I made one anyway

At first I wasn't sure if `identifer` was an intentional mis-spelling but any code uses `identifier` so I figured it's supposed to be `identifier` in all places. Let me know if that's not the case though!
